### PR TITLE
Add sequential item codes with previews and enforce uniqueness

### DIFF
--- a/src/main/java/com/project/SH/controller/ProductCodeApiController.java
+++ b/src/main/java/com/project/SH/controller/ProductCodeApiController.java
@@ -2,6 +2,7 @@ package com.project.SH.controller;
 
 import com.project.SH.domain.CompanyCode;
 import com.project.SH.domain.ProductCode;
+import com.project.SH.dto.NextItemCodeResponse;
 import com.project.SH.service.ProductCodeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -37,5 +38,12 @@ public class ProductCodeApiController {
                                   @RequestParam String categoryCode,
                                   @RequestParam(required = false) String description) {
         return productCodeService.createProductCode(companyCode, typeCode, categoryCode, description);
+    }
+
+    @GetMapping("/next-item")
+    public NextItemCodeResponse getNextItemCode(@RequestParam String companyCode,
+                                                @RequestParam String typeCode,
+                                                @RequestParam String categoryCode) {
+        return productCodeService.previewNextItemCode(companyCode, typeCode, categoryCode);
     }
 }

--- a/src/main/java/com/project/SH/domain/CategoryCode.java
+++ b/src/main/java/com/project/SH/domain/CategoryCode.java
@@ -1,0 +1,28 @@
+package com.project.SH.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "category_code")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryCode {
+
+    @Id
+    @Column(name = "category_code", length = 10)
+    private String categoryCode;
+
+    @Column(name = "category_name", nullable = false, length = 100)
+    private String categoryName;
+}

--- a/src/main/java/com/project/SH/domain/Product.java
+++ b/src/main/java/com/project/SH/domain/Product.java
@@ -120,6 +120,17 @@ public class Product {
     public String getItemCode() { return item_code; }
     public void setItemCode(String item_code) { this.item_code = item_code; }
 
+    @Transient
+    public String getFullProductCode() {
+        if (product_code == null || product_code.isBlank()) {
+            return item_code != null ? item_code : "";
+        }
+        if (item_code == null || item_code.isBlank()) {
+            return product_code;
+        }
+        return product_code + "_" + item_code;
+    }
+
     public String getPdName() { return pd_name; }
     public void setPdName(String pd_name) { this.pd_name = pd_name; }
 

--- a/src/main/java/com/project/SH/domain/TypeCode.java
+++ b/src/main/java/com/project/SH/domain/TypeCode.java
@@ -1,0 +1,28 @@
+package com.project.SH.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "type_code")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TypeCode {
+
+    @Id
+    @Column(name = "type_code", length = 10)
+    private String typeCode;
+
+    @Column(name = "type_name", nullable = false, length = 100)
+    private String typeName;
+}

--- a/src/main/java/com/project/SH/dto/NextItemCodeResponse.java
+++ b/src/main/java/com/project/SH/dto/NextItemCodeResponse.java
@@ -1,0 +1,4 @@
+package com.project.SH.dto;
+
+public record NextItemCodeResponse(String productCode, String itemCode, String fullProductCode) {
+}

--- a/src/main/java/com/project/SH/repository/CategoryCodeRepository.java
+++ b/src/main/java/com/project/SH/repository/CategoryCodeRepository.java
@@ -1,0 +1,7 @@
+package com.project.SH.repository;
+
+import com.project.SH.domain.CategoryCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryCodeRepository extends JpaRepository<CategoryCode, String> {
+}

--- a/src/main/java/com/project/SH/repository/ProductRepository.java
+++ b/src/main/java/com/project/SH/repository/ProductRepository.java
@@ -4,31 +4,40 @@ import com.project.SH.domain.Product;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    @Query("SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END FROM Product p WHERE p.product_code = :productCode")
-    boolean existsByProductCode(@Param("productCode") String productCode);
+    @Query("SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END " +
+            "FROM Product p " +
+            "WHERE p.product_code = :productCode " +
+            "AND ((:itemCode IS NULL AND p.item_code IS NULL) OR p.item_code = :itemCode)")
+    boolean existsByProductCodeAndItemCode(@Param("productCode") String productCode,
+                                           @Param("itemCode") String itemCode);
 
-    @Query("SELECT p FROM Product p WHERE p.product_code = :productCode")
-    Product findByProductCode(@Param("productCode") String productCode);
+    @Query(value = "SELECT * FROM product_tb WHERE product_code = :productCode ORDER BY item_code DESC LIMIT 1",
+            nativeQuery = true)
+    Optional<Product> findTopByProductCodeOrderByItemCodeDesc(@Param("productCode") String productCode);
 
     List<Product> findAll(Sort sort);
 
     @Query("SELECT DISTINCT p FROM Product p LEFT JOIN FETCH p.prices LEFT JOIN FETCH p.stock LEFT JOIN FETCH p.user")
     List<Product> findAllWithPricesAndStock();
 
-    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.stock LEFT JOIN FETCH p.user WHERE p.product_code = :productCode")
-    Product findByProductCodeWithStock(@Param("productCode") String productCode);
+    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.stock LEFT JOIN FETCH p.user " +
+            "WHERE p.product_code = :productCode AND p.item_code = :itemCode")
+    Product findByProductCodeAndItemCodeWithStock(@Param("productCode") String productCode,
+                                                  @Param("itemCode") String itemCode);
 
     @Query("SELECT DISTINCT p FROM Product p LEFT JOIN FETCH p.stock LEFT JOIN FETCH p.user " +
             "WHERE p.product_code LIKE %:keyword% " +
             "OR p.item_code LIKE %:keyword% " +
+            "OR CONCAT(p.product_code, '_', COALESCE(p.item_code, '')) LIKE %:keyword% " +
             "OR p.spec LIKE %:keyword% " +
             "OR p.pd_name LIKE %:keyword%")
     List<Product> searchAllByKeyword(@Param("keyword") String keyword);

--- a/src/main/java/com/project/SH/repository/TypeCodeRepository.java
+++ b/src/main/java/com/project/SH/repository/TypeCodeRepository.java
@@ -1,0 +1,7 @@
+package com.project.SH.repository;
+
+import com.project.SH.domain.TypeCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TypeCodeRepository extends JpaRepository<TypeCode, String> {
+}

--- a/src/main/java/com/project/SH/service/PriceService.java
+++ b/src/main/java/com/project/SH/service/PriceService.java
@@ -19,7 +19,7 @@ public class PriceService implements PriceServiceImpl {
 
     public void registerPrice(Product product, Double price, Long accountSeq) {
         try {
-            log.info("가격 등록 시작, 상품 코드: {}, 가격: {}, 수정자 번호: {}", product.getProductCode(), price, accountSeq);
+            log.info("가격 등록 시작, 상품 코드: {}, 가격: {}, 수정자 번호: {}", product.getFullProductCode(), price, accountSeq);
 
             // 가격 테이블에 새로운 가격 기록 저장
             Price priceRecord = new Price();
@@ -29,22 +29,22 @@ public class PriceService implements PriceServiceImpl {
             priceRecord.setReason("상품 등록 시 가격");
             priceRepository.save(priceRecord);
 
-            log.info("가격 등록 성공, 상품 코드: {}", product.getProductCode());
+            log.info("가격 등록 성공, 상품 코드: {}", product.getFullProductCode());
         } catch (Exception e) {
-            log.error("가격 등록 실패, 상품 코드: {}, 에러: {}", product.getProductCode(), e.getMessage());
+            log.error("가격 등록 실패, 상품 코드: {}, 에러: {}", product.getFullProductCode(), e.getMessage());
             throw new RuntimeException("가격 등록 실패", e);
         }
     }
 
     public Double getLatestPrice(Product product) {
-        log.info("상품 코드: {}의 최신 가격을 조회", product.getProductCode());
+        log.info("상품 코드: {}의 최신 가격을 조회", product.getFullProductCode());
         Optional<Price> latest = priceRepository.findFirstByProductOrderByCreatedAtDesc(product);
         return latest.map(price -> {
                     log.info("가장 최근 가격: {}", price.getPrice());
                     return price.getPrice();
                 })
                 .orElseGet(() -> {
-                    log.warn("상품 코드: {}의 가격이 없습니다.", product.getProductCode());
+                    log.warn("상품 코드: {}의 가격이 없습니다.", product.getFullProductCode());
                     return 0.0;
                 });
     }

--- a/src/main/java/com/project/SH/service/ProductCodeService.java
+++ b/src/main/java/com/project/SH/service/ProductCodeService.java
@@ -1,13 +1,19 @@
 package com.project.SH.service;
 
+import com.project.SH.domain.CategoryCode;
 import com.project.SH.domain.CompanyCode;
+import com.project.SH.domain.Product;
 import com.project.SH.domain.ProductCode;
+import com.project.SH.domain.TypeCode;
+import com.project.SH.dto.NextItemCodeResponse;
+import com.project.SH.repository.CategoryCodeRepository;
 import com.project.SH.repository.CompanyCodeRepository;
 import com.project.SH.repository.ProductCodeRepository;
+import com.project.SH.repository.ProductRepository;
+import com.project.SH.repository.TypeCodeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,8 +22,14 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ProductCodeService implements ProductCodeServiceImpl {
 
+    private static final String ROOT_CODE = "0000";
+    private static final int ITEM_CODE_LENGTH = 4;
+
     private final ProductCodeRepository productCodeRepository;
     private final CompanyCodeRepository companyCodeRepository;
+    private final TypeCodeRepository typeCodeRepository;
+    private final CategoryCodeRepository categoryCodeRepository;
+    private final ProductRepository productRepository;
 
     @Override
     public List<ProductCode> getAllProductCodes() {
@@ -26,20 +38,107 @@ public class ProductCodeService implements ProductCodeServiceImpl {
 
     @Override
     public ProductCode createProductCode(String companyCode, String typeCode, String categoryCode, String description) {
-        companyCodeRepository.findById(companyCode)
-                .orElseGet(() -> companyCodeRepository.save(CompanyCode.builder()
-                        .companyCode(companyCode)
-                        .companyName(description != null ? description : companyCode)
-                        .build()));
+        final String normalizedDescription = description != null ? description.trim() : null;
+        final boolean isCompanyLevel = ROOT_CODE.equals(typeCode) && ROOT_CODE.equals(categoryCode);
+        final boolean isTypeLevel = !ROOT_CODE.equals(typeCode) && ROOT_CODE.equals(categoryCode);
+        final boolean isCategoryLevel = !ROOT_CODE.equals(typeCode) && !ROOT_CODE.equals(categoryCode);
+
+        ensureTypeCode(ROOT_CODE, null);
+        ensureCategoryCode(ROOT_CODE, null);
+
+        final String resolvedDescription;
+        if (isCompanyLevel) {
+            resolvedDescription = resolveName(normalizedDescription, companyCode);
+        } else if (isTypeLevel) {
+            resolvedDescription = resolveName(normalizedDescription, typeCode);
+        } else if (isCategoryLevel) {
+            resolvedDescription = resolveName(normalizedDescription, categoryCode);
+        } else {
+            resolvedDescription = normalizedDescription;
+        }
+
+        if (isCompanyLevel) {
+            companyCodeRepository.findById(companyCode)
+                    .map(existing -> {
+                        if (normalizedDescription != null && !normalizedDescription.isBlank()
+                                && !normalizedDescription.equals(existing.getCompanyName())) {
+                            existing.setCompanyName(normalizedDescription);
+                            return companyCodeRepository.save(existing);
+                        }
+                        return existing;
+                    })
+                    .orElseGet(() -> companyCodeRepository.save(CompanyCode.builder()
+                            .companyCode(companyCode)
+                            .companyName(resolvedDescription)
+                            .build()));
+        } else {
+            companyCodeRepository.findById(companyCode)
+                    .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회사 코드입니다."));
+        }
+
+        if (isTypeLevel) {
+            ensureTypeCode(typeCode, normalizedDescription);
+        } else if (!ROOT_CODE.equals(typeCode)) {
+            ensureTypeCode(typeCode, null);
+        }
+
+        if (isCategoryLevel) {
+            ensureCategoryCode(categoryCode, normalizedDescription);
+        }
 
         return productCodeRepository
                 .findByCompanyCodeAndTypeCodeAndCategoryCode(companyCode, typeCode, categoryCode)
+                .map(existing -> updateDescriptionIfNeeded(existing, normalizedDescription))
                 .orElseGet(() -> productCodeRepository.save(ProductCode.builder()
                         .companyCode(companyCode)
                         .typeCode(typeCode)
                         .categoryCode(categoryCode)
-                        .description(description)
+                        .description(resolvedDescription)
                         .build()));
+    }
+
+    private ProductCode updateDescriptionIfNeeded(ProductCode code, String description) {
+        if (description != null && !description.isBlank() && !description.equals(code.getDescription())) {
+            code.setDescription(description);
+            return productCodeRepository.save(code);
+        }
+        return code;
+    }
+
+    private void ensureTypeCode(String typeCode, String description) {
+        final String resolvedName = resolveName(description, typeCode);
+        typeCodeRepository.findById(typeCode)
+                .map(existing -> {
+                    if (description != null && !description.isBlank() && !resolvedName.equals(existing.getTypeName())) {
+                        existing.setTypeName(resolvedName);
+                        return typeCodeRepository.save(existing);
+                    }
+                    return existing;
+                })
+                .orElseGet(() -> typeCodeRepository.save(TypeCode.builder()
+                        .typeCode(typeCode)
+                        .typeName(resolvedName)
+                        .build()));
+    }
+
+    private void ensureCategoryCode(String categoryCode, String description) {
+        final String resolvedName = resolveName(description, categoryCode);
+        categoryCodeRepository.findById(categoryCode)
+                .map(existing -> {
+                    if (description != null && !description.isBlank() && !resolvedName.equals(existing.getCategoryName())) {
+                        existing.setCategoryName(resolvedName);
+                        return categoryCodeRepository.save(existing);
+                    }
+                    return existing;
+                })
+                .orElseGet(() -> categoryCodeRepository.save(CategoryCode.builder()
+                        .categoryCode(categoryCode)
+                        .categoryName(resolvedName)
+                        .build()));
+    }
+
+    private String resolveName(String candidate, String fallback) {
+        return candidate != null && !candidate.isBlank() ? candidate : fallback;
     }
 
     @Override
@@ -51,12 +150,12 @@ public class ProductCodeService implements ProductCodeServiceImpl {
 
     @Override
     public List<ProductCode> getTypesByCompanyCode(String companyCode) {
-        return productCodeRepository.findByCompanyCodeAndCategoryCode(companyCode, "0000");
+        return productCodeRepository.findByCompanyCodeAndCategoryCode(companyCode, ROOT_CODE);
     }
 
     @Override
     public List<ProductCode> getCategoriesByCompanyCodeAndTypeCode(String companyCode, String typeCode) {
-        return productCodeRepository.findByCompanyCodeAndTypeCodeAndCategoryCodeNot(companyCode, typeCode, "0000");
+        return productCodeRepository.findByCompanyCodeAndTypeCodeAndCategoryCodeNot(companyCode, typeCode, ROOT_CODE);
     }
 
     @Override
@@ -71,10 +170,10 @@ public class ProductCodeService implements ProductCodeServiceImpl {
 
     @Override
     public Map<String, String> getTypeNameMap() {
-        List<ProductCode> types = productCodeRepository.findByCategoryCode("0000");
+        List<ProductCode> types = productCodeRepository.findByCategoryCode(ROOT_CODE);
         Map<String, String> map = new LinkedHashMap<>();
         for (ProductCode t : types) {
-            if (!"0000".equals(t.getTypeCode())) {
+            if (!ROOT_CODE.equals(t.getTypeCode())) {
                 map.putIfAbsent(t.getTypeCode(), t.getDescription());
             }
         }
@@ -83,11 +182,81 @@ public class ProductCodeService implements ProductCodeServiceImpl {
 
     @Override
     public Map<String, String> getCategoryNameMap() {
-        List<ProductCode> categories = productCodeRepository.findByCategoryCodeNot("0000");
+        List<ProductCode> categories = productCodeRepository.findByCategoryCodeNot(ROOT_CODE);
         Map<String, String> map = new LinkedHashMap<>();
         for (ProductCode cat : categories) {
             map.putIfAbsent(cat.getCategoryCode(), cat.getDescription());
         }
         return map;
+    }
+
+    @Override
+    public String getNextItemCodeForBase(String productCode) {
+        final String base = requireCode(productCode, "제품 코드");
+        return formatItemCode(determineNextValue(base));
+    }
+
+    public String getNextItemCode(String companyCode, String typeCode, String categoryCode) {
+        final String base = buildBaseProductCode(companyCode, typeCode, categoryCode);
+        return formatItemCode(determineNextValue(base));
+    }
+
+    @Override
+    public NextItemCodeResponse previewNextItemCode(String companyCode, String typeCode, String categoryCode) {
+        final String base = buildBaseProductCode(companyCode, typeCode, categoryCode);
+        final String itemCode = formatItemCode(determineNextValue(base));
+        return new NextItemCodeResponse(base, itemCode, buildFullProductCode(base, itemCode));
+    }
+
+    @Override
+    public String buildFullProductCode(String productCode, String itemCode) {
+        final String base = requireCode(productCode, "제품 코드");
+        final String item = itemCode != null ? itemCode.trim() : "";
+        if (item.isEmpty()) {
+            return base;
+        }
+        return base + "_" + item;
+    }
+
+    private String buildBaseProductCode(String companyCode, String typeCode, String categoryCode) {
+        final String company = requireCode(companyCode, "회사 코드");
+        final String type = requireCode(typeCode, "타입 코드");
+        final String category = requireCode(categoryCode, "카테고리 코드");
+        return String.join("_", company, type, category);
+    }
+
+    private int determineNextValue(String baseProductCode) {
+        final int lastValue = productRepository.findTopByProductCodeOrderByItemCodeDesc(baseProductCode)
+                .map(Product::getItemCode)
+                .map(this::parseItemCode)
+                .orElse(0);
+        return lastValue + 1;
+    }
+
+    private int parseItemCode(String value) {
+        if (value == null) {
+            return 0;
+        }
+        final String digits = value.replaceAll("\\D", "");
+        if (digits.isEmpty()) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(digits);
+        } catch (NumberFormatException ex) {
+            return 0;
+        }
+    }
+
+    private String formatItemCode(int value) {
+        return String.format("%0" + ITEM_CODE_LENGTH + "d", Math.max(value, 0));
+    }
+
+    private String requireCode(String value, String label) {
+        final String trimmed = value != null ? value.trim() : "";
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException(label + "는 필수입니다.");
+        }
+        return trimmed;
     }
 }

--- a/src/main/java/com/project/SH/service/ProductCodeServiceImpl.java
+++ b/src/main/java/com/project/SH/service/ProductCodeServiceImpl.java
@@ -2,6 +2,7 @@ package com.project.SH.service;
 
 import com.project.SH.domain.CompanyCode;
 import com.project.SH.domain.ProductCode;
+import com.project.SH.dto.NextItemCodeResponse;
 import java.util.List;
 
 
@@ -21,4 +22,10 @@ public interface ProductCodeServiceImpl {
     java.util.Map<String, String> getTypeNameMap();
 
     java.util.Map<String, String> getCategoryNameMap();
+
+    String getNextItemCodeForBase(String productCode);
+
+    NextItemCodeResponse previewNextItemCode(String companyCode, String typeCode, String categoryCode);
+
+    String buildFullProductCode(String productCode, String itemCode);
 }

--- a/src/main/java/com/project/SH/service/ProductServiceImpl.java
+++ b/src/main/java/com/project/SH/service/ProductServiceImpl.java
@@ -7,9 +7,9 @@ public interface ProductServiceImpl {
 
     void registerProduct(Product product, Double price, Integer piecesPerBox, Integer totalQty, Long accountSeq);
     List<Product> getAllProducts();
-    Product getProductByCode(String productCode);
+    Product getProductByCode(String productCode, String itemCode);
 
-    void updateProduct(String originalProductCode, Product updatedProduct,
+    void updateProduct(String originalProductCode, String originalItemCode, Product updatedProduct,
                        Integer piecesPerBox, Integer totalQty, Double price,
                        Long accountSeq, String reason, boolean isAdmin);
 

--- a/src/main/webapp/WEB-INF/views/inventory.jsp
+++ b/src/main/webapp/WEB-INF/views/inventory.jsp
@@ -94,8 +94,9 @@
                           </select>
                       </td>
                       <td>
-                          <a href="${pageContext.request.contextPath}/product/detail/${product.productCode}" class="btn btn-sm btn-outline-primary">상세</a>
+                          <a href="${pageContext.request.contextPath}/product/detail/${product.productCode}?itemCode=${product.itemCode}" class="btn btn-sm btn-outline-primary">상세</a>
                           <input type="hidden" name="originalCode" value="${product.productCode}">
+                          <input type="hidden" name="originalItemCode" value="${product.itemCode}">
                           <input type="text" name="reason" class="form-control form-control-sm mt-1 save-btn" placeholder="사유" style="display:none" required>
                           <button type="submit" class="btn btn-sm btn-success mt-1 save-btn" style="display:none">저장</button>
                       </td>

--- a/src/main/webapp/WEB-INF/views/product.jsp
+++ b/src/main/webapp/WEB-INF/views/product.jsp
@@ -17,7 +17,7 @@
         <table class="table table-hover align-middle text-center">
             <thead class="table-light">
             <tr>
-                <th>상품코드</th>
+                <th>제품코드</th>
                 <th>아이템코드</th>
                 <th>스펙</th>
                 <th>상품명</th>
@@ -45,7 +45,12 @@
                         </select>
                     </div>
                 </td>
-                <td><input type="text" name="itemCode" class="form-control form-control-sm" required></td>
+                <td>
+                    <div class="d-flex flex-column">
+                        <input type="text" name="itemCode" id="registerItemCode" class="form-control form-control-sm mb-1" readonly>
+                        <small class="text-muted" id="registerFullCodePreview">회사, 종류, 분류를 선택하면 제품 코드가 자동으로 생성됩니다.</small>
+                    </div>
+                </td>
                 <td><input type="text" name="spec" class="form-control form-control-sm" required></td>
                 <td><input type="text" name="pdName" class="form-control form-control-sm" required></td>
                 <td><input type="text" name="unitName" class="form-control form-control-sm" required></td>
@@ -71,7 +76,7 @@
 
             <c:forEach var="product" items="${productList}">
                 <tr class="${product.active ? '' : 'text-muted'}">
-                    <td>${product.productCode}</td>
+                    <td>${product.fullProductCode}</td>
                     <td>${product.itemCode}</td>
                     <td>${product.spec}</td>
                     <td>${product.pdName}</td>
@@ -104,6 +109,68 @@
         const companySelect = document.getElementById('companyCode');
         const typeSelect = document.getElementById('typeCode');
         const categorySelect = document.getElementById('categoryCode');
+        const itemCodeInput = document.getElementById('registerItemCode');
+        const fullCodePreview = document.getElementById('registerFullCodePreview');
+        const fullCodeDefaultText = fullCodePreview ? fullCodePreview.textContent : '';
+
+        function resetItemPreview() {
+            if (itemCodeInput) {
+                itemCodeInput.value = '';
+            }
+            if (fullCodePreview) {
+                fullCodePreview.textContent = fullCodeDefaultText;
+                fullCodePreview.classList.remove('text-danger');
+            }
+        }
+
+        async function refreshRegisterItemCode() {
+            if (!itemCodeInput) {
+                return;
+            }
+            const company = companySelect ? companySelect.value : '';
+            const type = typeSelect ? typeSelect.value : '';
+            const category = categorySelect ? categorySelect.value : '';
+
+            if (!company || !type || !category) {
+                resetItemPreview();
+                return;
+            }
+
+            try {
+                if (fullCodePreview) {
+                    fullCodePreview.classList.remove('text-danger');
+                }
+            const params = new URLSearchParams({
+                companyCode: company,
+                typeCode: type,
+                categoryCode: category,
+            });
+            const response = await fetch(ctx + '/api/product-codes/next-item?' + params.toString());
+                if (!response.ok) {
+                    throw new Error('failed to fetch next item code');
+                }
+                const data = await response.json();
+                itemCodeInput.value = data.itemCode || '';
+                if (fullCodePreview) {
+                    fullCodePreview.textContent = data.fullProductCode || fullCodeDefaultText;
+                }
+            } catch (error) {
+                console.error(error);
+                if (fullCodePreview) {
+                    fullCodePreview.textContent = '아이템 코드를 불러오지 못했습니다.';
+                    fullCodePreview.classList.add('text-danger');
+                }
+                itemCodeInput.value = '';
+            }
+        }
+
+        if (row.dataset.initialized === 'true') {
+            if (show) {
+                refreshRegisterItemCode();
+            }
+            return;
+        }
+        row.dataset.initialized = 'true';
 
         async function loadCompanies() {
             const res = await fetch(`${ctx}/api/product-codes/companies`);
@@ -114,6 +181,7 @@
                 option.textContent = c.companyName;
                 companySelect.appendChild(option);
             });
+            resetItemPreview();
         }
 
         companySelect.addEventListener('change', async () => {
@@ -121,6 +189,7 @@
             typeSelect.innerHTML = '<option value="">종류</option>';
             categorySelect.innerHTML = '<option value="">분류</option>';
             categorySelect.disabled = true;
+            resetItemPreview();
             if (selectedCompany) {
                 const res = await fetch(`${ctx}/api/product-codes/types?companyCode=${selectedCompany}`);
                 const data = await res.json();
@@ -134,6 +203,7 @@
             } else {
                 typeSelect.disabled = true;
             }
+            await refreshRegisterItemCode();
         });
 
         typeSelect.addEventListener('change', async () => {
@@ -153,9 +223,15 @@
             } else {
                 categorySelect.disabled = true;
             }
+            await refreshRegisterItemCode();
         });
 
+        categorySelect.addEventListener('change', refreshRegisterItemCode);
+
         loadCompanies();
+        if (show) {
+            refreshRegisterItemCode();
+        }
     }
   </script>
 </body>

--- a/src/main/webapp/WEB-INF/views/productdetail.jsp
+++ b/src/main/webapp/WEB-INF/views/productdetail.jsp
@@ -20,20 +20,18 @@
 
             <div id="codeForm">
                 <form id="codeRegisterForm">
-                    <div class="row mb-3">
+                    <div class="row g-3 mb-3 align-items-end">
                         <div class="col">
-                            <label class="form-label">회사 이름</label>
-                            <select id="codeCompanyName" class="form-select">
-                                <option value="">선택하시오</option>
-                                <option value="__custom__">직접입력</option>
-                            </select>
-                            <input id="codeCompanyNameInput" class="form-control mt-2" style="display:none;" placeholder="회사 이름을 입력하세요">
+                            <label class="form-label">회사 선택</label>
+                            <select id="codeCompanySelect" class="form-select"></select>
+                            <input id="codeCompanyName" class="form-control d-none" placeholder="회사 이름을 직접 입력하세요">
                         </div>
                         <div class="col">
                             <label class="form-label">회사 코드</label>
                             <input id="codeCompany" class="form-control" disabled>
                         </div>
-                        <div class="col-auto d-flex align-items-end">
+                        <div class="col-auto d-flex align-items-end gap-2">
+                            <button type="button" class="btn btn-outline-secondary" id="companyInputToggle">직접입력</button>
                             <button type="button" class="btn btn-secondary" id="companyPartialBtn">부분등록</button>
                         </div>
                     </div>
@@ -102,7 +100,8 @@
                     </div>
                     <div class="mb-3">
                         <label class="form-label">아이템 코드</label>
-                        <input type="text" name="itemCode" class="form-control" required>
+                        <input type="text" name="itemCode" id="productItemCode" class="form-control" readonly>
+                        <div class="form-text" id="productFullCodePreview">회사, 타입, 카테고리를 선택하면 제품 코드가 자동으로 생성됩니다.</div>
                     </div>
                     <div class="mb-3">
                         <label class="form-label">규격</label>
@@ -146,6 +145,10 @@
         </c:when>
         <c:otherwise>
                         <h2>제품 상세 정보</h2>
+                        <div class="mb-2">
+                            <span class="fw-semibold">전체 제품코드:</span>
+                            <span>${product.fullProductCode}</span>
+                        </div>
                         <button type="button" class="btn btn-warning mb-2" onclick="toggleDetailEdit()">수정</button>
                         <form action="${pageContext.request.contextPath}/product/update" method="post" id="detailForm">
                         <div class="table-responsive">
@@ -185,6 +188,7 @@
                     </table>
                 </div>
                 <input type="hidden" name="originalCode" value="${product.productCode}">
+                <input type="hidden" name="originalItemCode" value="${product.itemCode}">
                 <input type="text" name="reason" class="form-control mt-2 save-btn" placeholder="사유" style="display:none" required>
                 <button type="submit" class="btn btn-success mt-2 save-btn" style="display:none">저장</button>
                 </form>
@@ -215,8 +219,8 @@
         codeTabBtn.classList.remove('active');
     });
 
+    const codeCompanySelect = document.getElementById('codeCompanySelect');
     const codeCompanyName = document.getElementById('codeCompanyName');
-    const codeCompanyNameInput = document.getElementById('codeCompanyNameInput');
     const codeCompany = document.getElementById('codeCompany');
     const codeTypeName = document.getElementById('codeTypeName');
     const codeType = document.getElementById('codeType');
@@ -224,58 +228,27 @@
     const codeCategory = document.getElementById('codeCategory');
     const typeNameOptions = document.getElementById('typeNameOptions');
     const categoryNameOptions = document.getElementById('categoryNameOptions');
+    const companyInputToggle = document.getElementById('companyInputToggle');
     const companyPartialBtn = document.getElementById('companyPartialBtn');
     const typePartialBtn = document.getElementById('typePartialBtn');
     const categoryPartialBtn = document.getElementById('categoryPartialBtn');
 
-    function loadCompanies() {
-        fetch(`${ctx}/api/product-codes/companies`)
-            .then(r => r.json())
-            .then(data => {
-                codeCompanyName.innerHTML = '<option value="">선택하시오</option><option value="__custom__">직접입력</option>';
-                data.forEach(c => {
-                    const opt = document.createElement('option');
-                    opt.value = c.companyCode;
-                    opt.textContent = c.companyName;
-                    codeCompanyName.appendChild(opt);
-                });
-            })
-            .catch(() => alert('회사 목록을 불러오지 못했습니다. 관리자에 문의하시오'));
+    companyPartialBtn.disabled = true;
+
+    let customCompanyMode = false;
+    let currentCompanyCode = '';
+
+    function showSelectCompanyField() {
+        codeCompanySelect.classList.remove('d-none');
+        codeCompanyName.classList.add('d-none');
+        companyInputToggle.textContent = '직접입력';
     }
 
-    function loadTypes(company) {
-        fetch(`${ctx}/api/product-codes/types?companyCode=${company}`)
-            .then(r => r.json())
-            .then(data => {
-                typeNameOptions.innerHTML = '';
-                data.forEach(t => {
-                    if (t.typeCode !== '0000') {
-                        const opt = document.createElement('option');
-                        opt.value = t.description;
-                        opt.dataset.code = t.typeCode;
-                        typeNameOptions.appendChild(opt);
-                    }
-                });
-            })
-            .catch(() => alert('관리자에 문의하시오'));
+    function showCustomCompanyField() {
+        codeCompanySelect.classList.add('d-none');
+        codeCompanyName.classList.remove('d-none');
+        companyInputToggle.textContent = '목록선택';
     }
-
-    function loadCategories(company, type) {
-        fetch(`${ctx}/api/product-codes/categories?companyCode=${company}&typeCode=${type}`)
-            .then(r => r.json())
-            .then(data => {
-                categoryNameOptions.innerHTML = '';
-                data.forEach(cat => {
-                    const opt = document.createElement('option');
-                    opt.value = cat.description;
-                    opt.dataset.code = cat.categoryCode;
-                    categoryNameOptions.appendChild(opt);
-                });
-            })
-            .catch(() => alert('관리자에 문의하시오'));
-    }
-
-    loadCompanies();
 
     function resetTypeFields() {
         codeTypeName.value = '';
@@ -295,43 +268,230 @@
         categoryNameOptions.innerHTML = '';
     }
 
-    function updateTypeEnable() {
-        const nameFilled = codeCompanyName.value === '__custom__' ? codeCompanyNameInput.value.trim() : codeCompanyName.value;
-        const hasCompany = nameFilled && codeCompany.value.trim();
-        codeTypeName.disabled = !hasCompany;
-        typePartialBtn.disabled = !hasCompany;
-        if (!hasCompany) {
-            resetTypeFields();
-            resetCategoryFields();
+    function syncCompanyPartialButton() {
+        if (customCompanyMode) {
+            const hasName = codeCompanyName.value.trim();
+            const hasCode = codeCompany.value.trim();
+            companyPartialBtn.disabled = !(hasName && hasCode);
+        } else {
+            companyPartialBtn.disabled = true;
         }
     }
 
-    codeCompanyName.addEventListener('change', () => {
-        if (codeCompanyName.value === '__custom__') {
-            // 직접입력: 회사 이름/코드 입력 가능
-            codeCompanyNameInput.style.display = '';
-            codeCompany.value = '';
-            codeCompany.disabled = false;
-        } else if (codeCompanyName.value) {
-            // DB에서 선택한 경우: 코드 자동 입력 후 비활성화
-            codeCompanyNameInput.style.display = 'none';
-            codeCompany.value = codeCompanyName.value;
-            codeCompany.disabled = true;
-            loadTypes(codeCompany.value);
-        } else {
-            // 선택 해제: 입력폼 초기화 및 비활성화
-            codeCompanyNameInput.style.display = 'none';
-            codeCompany.value = '';
-            codeCompany.disabled = true;
+    function updateTypeEnable() {
+        const hasCompany = customCompanyMode
+            ? Boolean(codeCompanyName.value.trim() && codeCompany.value.trim())
+            : Boolean(currentCompanyCode);
+        codeTypeName.disabled = !hasCompany;
+        typePartialBtn.disabled = !hasCompany;
+        if (!hasCompany) {
+            codeType.value = '';
+            codeType.disabled = true;
+            codeCategoryName.value = '';
+            codeCategoryName.disabled = true;
+            codeCategory.value = '';
+            codeCategory.disabled = true;
+            typeNameOptions.innerHTML = '';
+            categoryPartialBtn.disabled = true;
+            categoryNameOptions.innerHTML = '';
         }
+        syncCompanyPartialButton();
+    }
 
-        resetTypeFields();
-        resetCategoryFields();
+    function switchToExistingCompany(name, code) {
+        const changed = customCompanyMode || currentCompanyCode !== code;
+        currentCompanyCode = code;
+        customCompanyMode = false;
+        showSelectCompanyField();
+        const placeholder = codeCompanySelect.querySelector('option[value=""]');
+        if (placeholder) {
+            placeholder.selected = false;
+        }
+        codeCompanySelect.value = code;
+        codeCompanyName.value = name;
+        codeCompany.value = code;
+        codeCompany.disabled = true;
+        if (changed) {
+            resetTypeFields();
+            resetCategoryFields();
+        }
         updateTypeEnable();
+        return changed;
+    }
+
+    function switchToCustomCompany(name) {
+        const enteringCustom = !customCompanyMode;
+        if (enteringCustom || currentCompanyCode) {
+            resetTypeFields();
+            resetCategoryFields();
+            codeCompany.value = '';
+        }
+        currentCompanyCode = '';
+        customCompanyMode = true;
+        showCustomCompanyField();
+        codeCompanySelect.value = '';
+        codeCompanyName.value = name;
+        codeCompany.disabled = false;
+        updateTypeEnable();
+        if (!name) {
+            codeCompanyName.focus();
+        }
+    }
+
+    function clearCompanySelection() {
+        if (customCompanyMode || currentCompanyCode) {
+            resetTypeFields();
+            resetCategoryFields();
+        }
+        currentCompanyCode = '';
+        customCompanyMode = false;
+        showSelectCompanyField();
+        const placeholder = codeCompanySelect.querySelector('option[value=""]');
+        if (placeholder) {
+            placeholder.selected = true;
+        }
+        codeCompanySelect.value = '';
+        codeCompanyName.value = '';
+        codeCompany.value = '';
+        codeCompany.disabled = true;
+        updateTypeEnable();
+    }
+
+    function getSelectedCompanyName() {
+        if (customCompanyMode) {
+            return codeCompanyName.value.trim();
+        }
+        const selectedOption = codeCompanySelect.options[codeCompanySelect.selectedIndex];
+        if (!selectedOption || selectedOption.disabled) {
+            return '';
+        }
+        return selectedOption.textContent.trim();
+    }
+
+    function loadCompanies({ selectedCode } = {}) {
+        return fetch(`${ctx}/api/product-codes/companies`)
+            .then(r => {
+                if (!r.ok) {
+                    throw new Error('failed to fetch companies');
+                }
+                return r.json();
+            })
+            .then(data => {
+                codeCompanySelect.innerHTML = '';
+                const placeholder = document.createElement('option');
+                placeholder.value = '';
+                placeholder.textContent = '회사 선택';
+                placeholder.disabled = true;
+                codeCompanySelect.appendChild(placeholder);
+
+                data.forEach(c => {
+                    const opt = document.createElement('option');
+                    opt.value = c.companyCode;
+                    opt.textContent = c.companyName;
+                    codeCompanySelect.appendChild(opt);
+                });
+
+                const targetCode = selectedCode || currentCompanyCode;
+                if (targetCode) {
+                    const match = data.find(c => c.companyCode === targetCode);
+                    if (match) {
+                        switchToExistingCompany(match.companyName, match.companyCode);
+                    } else if (!customCompanyMode) {
+                        clearCompanySelection();
+                    }
+                } else {
+                    placeholder.selected = true;
+                }
+                updateTypeEnable();
+            })
+            .catch(err => {
+                alert('회사 목록을 불러오지 못했습니다. 관리자에 문의하시오');
+                throw err;
+            });
+    }
+
+    function loadTypes(company) {
+        return fetch(`${ctx}/api/product-codes/types?companyCode=${company}`)
+            .then(r => {
+                if (!r.ok) {
+                    throw new Error('failed to fetch types');
+                }
+                return r.json();
+            })
+            .then(data => {
+                typeNameOptions.innerHTML = '';
+                data.forEach(t => {
+                    if (t.typeCode !== '0000') {
+                        const opt = document.createElement('option');
+                        opt.value = t.description;
+                        opt.dataset.code = t.typeCode;
+                        typeNameOptions.appendChild(opt);
+                    }
+                });
+            })
+            .catch(err => {
+                alert('관리자에 문의하시오');
+                throw err;
+            });
+    }
+
+    function loadCategories(company, type) {
+        return fetch(`${ctx}/api/product-codes/categories?companyCode=${company}&typeCode=${type}`)
+            .then(r => {
+                if (!r.ok) {
+                    throw new Error('failed to fetch categories');
+                }
+                return r.json();
+            })
+            .then(data => {
+                categoryNameOptions.innerHTML = '';
+                data.forEach(cat => {
+                    const opt = document.createElement('option');
+                    opt.value = cat.description;
+                    opt.dataset.code = cat.categoryCode;
+                    categoryNameOptions.appendChild(opt);
+                });
+            })
+            .catch(err => {
+                alert('관리자에 문의하시오');
+                throw err;
+            });
+    }
+
+    clearCompanySelection();
+    loadCompanies();
+
+    codeCompanySelect.addEventListener('change', () => {
+        const selectedCode = codeCompanySelect.value;
+        if (!selectedCode) {
+            clearCompanySelection();
+            return;
+        }
+        const selectedOption = codeCompanySelect.options[codeCompanySelect.selectedIndex];
+        switchToExistingCompany(selectedOption ? selectedOption.textContent : '', selectedCode);
+        loadTypes(selectedCode);
     });
 
-    codeCompany.addEventListener('input', updateTypeEnable);
-    codeCompanyNameInput.addEventListener('input', updateTypeEnable);
+    companyInputToggle.addEventListener('click', () => {
+        if (customCompanyMode) {
+            clearCompanySelection();
+        } else {
+            switchToCustomCompany('');
+        }
+    });
+
+    codeCompanyName.addEventListener('input', () => {
+        if (customCompanyMode) {
+            updateTypeEnable();
+            syncCompanyPartialButton();
+        }
+    });
+
+    codeCompany.addEventListener('input', () => {
+        if (customCompanyMode) {
+            updateTypeEnable();
+        }
+    });
 
     codeTypeName.addEventListener('input', () => {
         const option = Array.from(typeNameOptions.options).find(o => o.value === codeTypeName.value);
@@ -368,30 +528,40 @@
         }
     });
 
-    companyPartialBtn.addEventListener('click', () => {
-        if (codeCompanyName.value !== '__custom__') {
-            alert('직접입력을 선택하세요');
+    async function postProductCode(params) {
+        const response = await fetch(`${ctx}/api/product-codes`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams(params)
+        });
+        if (!response.ok) {
+            throw new Error('failed to create product code');
+        }
+        return response.json();
+    }
+
+    companyPartialBtn.addEventListener('click', async () => {
+        if (!customCompanyMode) {
+            alert('새 회사 이름을 입력한 뒤에만 등록할 수 있습니다.');
             return;
         }
-        const name = codeCompanyNameInput.value.trim();
+        const name = codeCompanyName.value.trim();
         const code = codeCompany.value.trim();
         if (!name || !code) {
             alert('회사 이름과 코드를 입력하세요');
             return;
         }
-        fetch(`${ctx}/api/product-codes`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams({ companyCode: code, typeCode: '0000', categoryCode: '0000', description: name })
-        })
-            .then(() => {
-                alert('등록되었습니다.');
-                loadCompanies();
-            })
-            .catch(() => alert('관리자에 문의하시오'));
+        try {
+            await postProductCode({ companyCode: code, typeCode: '0000', categoryCode: '0000', description: name });
+            alert('등록되었습니다.');
+            await loadCompanies({ selectedCode: code });
+        } catch (e) {
+            console.error(e);
+            alert('관리자에 문의하시오');
+        }
     });
 
-    typePartialBtn.addEventListener('click', () => {
+    typePartialBtn.addEventListener('click', async () => {
         const company = codeCompany.value.trim();
         const name = codeTypeName.value.trim();
         const type = codeType.value.trim();
@@ -399,19 +569,25 @@
             alert('회사와 타입 이름, 코드를 입력하세요');
             return;
         }
-        fetch(`${ctx}/api/product-codes`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams({ companyCode: company, typeCode: type, categoryCode: '0000', description: name })
-        })
-            .then(() => {
-                alert('등록되었습니다.');
-                loadTypes(company);
-            })
-            .catch(() => alert('관리자에 문의하시오'));
+        try {
+            await postProductCode({ companyCode: company, typeCode: type, categoryCode: '0000', description: name });
+            alert('등록되었습니다.');
+            await loadTypes(company);
+            const option = Array.from(typeNameOptions.options).find(o => o.dataset.code === type);
+            if (option) {
+                codeTypeName.value = option.value;
+                codeType.value = option.dataset.code;
+                codeType.disabled = true;
+                codeCategoryName.disabled = false;
+                categoryPartialBtn.disabled = false;
+            }
+        } catch (e) {
+            console.error(e);
+            alert('관리자에 문의하시오');
+        }
     });
 
-    categoryPartialBtn.addEventListener('click', () => {
+    categoryPartialBtn.addEventListener('click', async () => {
         const company = codeCompany.value.trim();
         const type = codeType.value.trim();
         const name = codeCategoryName.value.trim();
@@ -420,48 +596,150 @@
             alert('회사, 타입, 카테고리 이름과 코드를 입력하세요');
             return;
         }
-        fetch(`${ctx}/api/product-codes`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams({ companyCode: company, typeCode: type, categoryCode: category, description: name })
-        })
-            .then(() => {
-                alert('등록되었습니다.');
-                loadCategories(company, type);
-            })
-            .catch(() => alert('관리자에 문의하시오'));
+        try {
+            await postProductCode({ companyCode: company, typeCode: type, categoryCode: category, description: name });
+            alert('등록되었습니다.');
+            await loadCategories(company, type);
+            const option = Array.from(categoryNameOptions.options).find(o => o.dataset.code === category);
+            if (option) {
+                codeCategoryName.value = option.value;
+                codeCategory.value = option.dataset.code;
+                codeCategory.disabled = true;
+            }
+        } catch (e) {
+            console.error(e);
+            alert('관리자에 문의하시오');
+        }
     });
 
-    document.getElementById('fullRegisterBtn').addEventListener('click', () => {
-        if (!codeCompany.value || !codeType.value || !codeCategory.value) {
-            alert('모든 코드를 입력하세요');
+    document.getElementById('fullRegisterBtn').addEventListener('click', async () => {
+        const company = codeCompany.value.trim();
+        const type = codeType.value.trim();
+        const category = codeCategory.value.trim();
+        const typeName = codeTypeName.value.trim();
+        const categoryName = codeCategoryName.value.trim();
+        const companyName = getSelectedCompanyName();
+        const wasCustomCompany = customCompanyMode;
+
+        if (!company || !type || !category || !typeName || !categoryName || (wasCustomCompany && !companyName)) {
+            alert('회사, 타입, 카테고리 이름과 코드를 모두 입력하세요');
             return;
         }
-        fetch(`${ctx}/api/product-codes`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams({ companyCode: codeCompany.value, typeCode: codeType.value, categoryCode: codeCategory.value, description: codeCategoryName.value })
-        })
-            .then(() => {
-                alert('제품코드가 등록되었습니다.');
-                document.getElementById('companyCode').value = codeCompany.value;
-                document.getElementById('companyCode').dispatchEvent(new Event('change'));
+
+        try {
+            if (wasCustomCompany) {
+                await postProductCode({ companyCode: company, typeCode: '0000', categoryCode: '0000', description: companyName });
+            }
+
+            await postProductCode({ companyCode: company, typeCode: type, categoryCode: '0000', description: typeName });
+
+            await postProductCode({ companyCode: company, typeCode: type, categoryCode: category, description: categoryName });
+
+            if (wasCustomCompany) {
+                await loadCompanies({ selectedCode: company });
+            }
+
+            await loadTypes(company);
+            const typeOption = Array.from(typeNameOptions.options).find(o => o.dataset.code === type);
+            if (typeOption) {
+                codeTypeName.value = typeOption.value;
+                codeType.value = typeOption.dataset.code;
+                codeType.disabled = true;
+                codeCategoryName.disabled = false;
+                categoryPartialBtn.disabled = false;
+            }
+
+            await loadCategories(company, type);
+            const categoryOption = Array.from(categoryNameOptions.options).find(o => o.dataset.code === category);
+            if (categoryOption) {
+                codeCategoryName.value = categoryOption.value;
+                codeCategory.value = categoryOption.dataset.code;
+                codeCategory.disabled = true;
+                categoryPartialBtn.disabled = false;
+            }
+
+            codeCompany.value = company;
+            codeCompany.disabled = true;
+            updateTypeEnable();
+
+            alert('제품코드가 등록되었습니다.');
+
+            document.getElementById('companyCode').value = codeCompany.value;
+            document.getElementById('companyCode').dispatchEvent(new Event('change'));
+            setTimeout(() => {
+                document.getElementById('typeCode').value = codeType.value;
+                document.getElementById('typeCode').dispatchEvent(new Event('change'));
                 setTimeout(() => {
-                    document.getElementById('typeCode').value = codeType.value;
-                    document.getElementById('typeCode').dispatchEvent(new Event('change'));
-                    setTimeout(() => {
-                        document.getElementById('categoryCode').value = codeCategory.value;
-                    }, 100);
+                    const categorySelectEl = document.getElementById('categoryCode');
+                    categorySelectEl.value = codeCategory.value;
+                    categorySelectEl.dispatchEvent(new Event('change'));
                 }, 100);
-                productTabBtn.click();
-            })
-            .catch(() => alert('관리자에 문의하시오'));
+            }, 100);
+            productTabBtn.click();
+        } catch (e) {
+            console.error(e);
+            alert('관리자에 문의하시오');
+        }
     });
 
     // ----- 제품 등록 폼 -----
     const companySelect = document.getElementById('companyCode');
     const typeSelect = document.getElementById('typeCode');
     const categorySelect = document.getElementById('categoryCode');
+    const productItemCodeInput = document.getElementById('productItemCode');
+    const productFullCodePreview = document.getElementById('productFullCodePreview');
+    const productFullCodeDefaultText = productFullCodePreview ? productFullCodePreview.textContent : '';
+
+    function resetProductItemPreview() {
+        if (productItemCodeInput) {
+            productItemCodeInput.value = '';
+        }
+        if (productFullCodePreview) {
+            productFullCodePreview.textContent = productFullCodeDefaultText;
+            productFullCodePreview.classList.remove('text-danger');
+        }
+    }
+
+    async function refreshProductItemCode() {
+        if (!productItemCodeInput) {
+            return;
+        }
+        const company = companySelect ? companySelect.value : '';
+        const type = typeSelect ? typeSelect.value : '';
+        const category = categorySelect ? categorySelect.value : '';
+
+        if (!company || !type || !category) {
+            resetProductItemPreview();
+            return;
+        }
+
+        try {
+            if (productFullCodePreview) {
+                productFullCodePreview.classList.remove('text-danger');
+            }
+            const params = new URLSearchParams({
+                companyCode: company,
+                typeCode: type,
+                categoryCode: category,
+            });
+            const response = await fetch(ctx + '/api/product-codes/next-item?' + params.toString());
+            if (!response.ok) {
+                throw new Error('failed to fetch next item code');
+            }
+            const data = await response.json();
+            productItemCodeInput.value = data.itemCode || '';
+            if (productFullCodePreview) {
+                productFullCodePreview.textContent = data.fullProductCode || productFullCodeDefaultText;
+            }
+        } catch (error) {
+            console.error(error);
+            if (productFullCodePreview) {
+                productFullCodePreview.textContent = '아이템 코드를 불러오지 못했습니다.';
+                productFullCodePreview.classList.add('text-danger');
+            }
+            productItemCodeInput.value = '';
+        }
+    }
 
     function updateTypeCategory() {
         if (!companySelect || !typeSelect || !categorySelect) return;
@@ -471,6 +749,7 @@
             categorySelect.value = '';
             typeSelect.disabled = true;
             categorySelect.disabled = true;
+            resetProductItemPreview();
             return;
         }
 
@@ -479,19 +758,35 @@
         if (!typeSelect.value) {
             categorySelect.value = '';
             categorySelect.disabled = true;
+            resetProductItemPreview();
         } else {
             categorySelect.disabled = false;
+            if (!categorySelect.value) {
+                resetProductItemPreview();
+            }
         }
     }
 
     if (companySelect) {
-        companySelect.addEventListener('change', updateTypeCategory);
+        companySelect.addEventListener('change', () => {
+            updateTypeCategory();
+            refreshProductItemCode();
+        });
     }
 
     if (typeSelect) {
-        typeSelect.addEventListener('change', updateTypeCategory);
+        typeSelect.addEventListener('change', () => {
+            updateTypeCategory();
+            refreshProductItemCode();
+        });
     }
+
+    if (categorySelect) {
+        categorySelect.addEventListener('change', refreshProductItemCode);
+    }
+
     updateTypeCategory();
+    refreshProductItemCode();
 
     // ----- 상세 정보 수정 -----
     let detailEditMode = false;

--- a/src/main/webapp/WEB-INF/views/productdetailall.jsp
+++ b/src/main/webapp/WEB-INF/views/productdetailall.jsp
@@ -21,8 +21,8 @@
             <thead class="table-light">
             <tr>
                 <th>등록자</th>
-                <th>상품코드</th>
                 <th>제품코드</th>
+                <th>아이템코드</th>
                 <th>규격</th>
                 <th>제품이름</th>
                 <th>박스당 수량</th>
@@ -40,7 +40,7 @@
             <c:forEach var="product" items="${productList}">
                 <tr class="${product.active ? '' : 'text-muted'}">
                     <td><c:out value="${product.user.name}"/></td>
-                    <td>${product.productCode}</td>
+                    <td>${product.fullProductCode}</td>
                     <td>${product.itemCode}</td>
                     <td>${product.spec}</td>
                     <td>${product.pdName}</td>


### PR DESCRIPTION
## Summary
- generate the next item code per product base code in ProductService, add uniqueness checks for admin edits, and expose helpers for building full codes
- add a REST endpoint returning the next item code preview and update product registration/detail UIs to auto-fill read-only item codes and show full product codes
- switch controller routes, repositories, and views to include item code parameters so full product codes remain unique and searchable
- fix the product registration/detail JSP fetch URLs to build query strings with URLSearchParams so the pages render without EL errors

## Testing
- sh gradlew test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c8bfdf7be8833183011dd96cedfbce